### PR TITLE
Support Netlify deploys for jrbeverly.dev domain

### DIFF
--- a/.github/workflows/jrbeverly.dev.netlify.yml
+++ b/.github/workflows/jrbeverly.dev.netlify.yml
@@ -21,4 +21,4 @@ jobs:
           args: hugo --verbose --minify -s srv/jrbeverly.dev -d artifacts
       - uses: docker://cardboardci/netlify:latest
         with:
-          args: "netlify deploy --dir -s srv/jrbeverly.dev/artifacts --site ${{ secrets.NETLIFY_JRBEVERLY_DEV }} --auth ${{ secrets.NETLIFY_TOKEN }} --prod"
+          args: "netlify deploy --dir srv/jrbeverly.dev/artifacts --site ${{ secrets.NETLIFY_JRBEVERLY_DEV }} --auth ${{ secrets.NETLIFY_TOKEN }} --prod"


### PR DESCRIPTION
Support a simple build and netlify deploy for the jrbeverly.dev.

This removes the auto-deploy pipeline process from the repository jrbeverly.dev.

The repository can now be deprecated.